### PR TITLE
Support browsers identified as 'Mobile Safari'

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function getBrowserName(agent) {
     return 'ie_mob';
   } else if (agent.browser.name === 'Opera Mobi') {
     return 'op_mob';
-  } else if (agent.browser.name === 'Safari' && agent.os.name === 'iOS') {
+  } else if ((agent.browser.name === 'Safari' || agent.browser.name === 'Mobile Safari') && agent.os.name === 'iOS') {
     return 'ios_saf';
   } else if (agent.browser.name === 'UCBrowser') {
     return 'and_uc';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "version"
   ],
   "dependencies": {
-    "browserslist": "^4.7.2",
+    "browserslist": "4.8.3",
     "ua-parser-js": "^0.7.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "version"
   ],
   "dependencies": {
-    "browserslist": "^4.4.1",
+    "browserslist": "^4.7.2",
     "ua-parser-js": "^0.7.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "version"
   ],
   "dependencies": {
-    "browserslist": "4.8.3",
+    "browserslist": "4.9.1",
     "ua-parser-js": "^0.7.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "version"
   ],
   "dependencies": {
-    "browserslist": "^2.3.3",
+    "browserslist": "^4.3.3",
     "ua-parser-js": "^0.7.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "version"
   ],
   "dependencies": {
-    "browserslist": "^4.3.3",
+    "browserslist": "^4.4.1",
     "ua-parser-js": "^0.7.14"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -87,6 +87,11 @@ describe('isBrowserSupported()', function () {
     {
       userAgent: 'Googlebot/2.1 (+http://www.google.com/bot.html)',
       expected: false
+    },
+    {
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+      selections: 'iOS >= 10',
+      expected: true
     }
   ];
 


### PR DESCRIPTION
The library is failing to recognize browsers which `ua-parser-js` identifies as "Mobile Safari." This pull request properly identifies those browsers under the `browserslist` category "ios_saf."

Example useragent string taken from: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent